### PR TITLE
downgrading nanos-secure-sdk dependencies to 1.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,8 @@ RUN /tmp/install_compiler.sh
 
 # Python
 RUN apt-get update && apt-get -y install python3 python3-dev python3-pip libjpeg-dev libffi-dev libssl-dev  cython libhidapi-dev
-RUN pip3 install -U setuptools pillow ledgerblue
+RUN pip3 install -U setuptools pillow
+RUN pip3 install ledgerblue
 
 # ENV
 RUN echo "export BOLOS_SDK=/opt/bolos/nanos-secure-sdk" >> /home/test/.bashrc

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ ENV BOLOS_ENV=/opt/bolos
 ENV BOLOS_SDK=$BOLOS_ENV/nanos-secure-sdk
 #ENV BOLOS_SDK=$BOLOS_ENV/blue-secure-sdk
 
-RUN sudo git clone https://github.com/LedgerHQ/nanos-secure-sdk.git $BOLOS_ENV/nanos-secure-sdk
+RUN sudo git clone --single-branch --branch og-1.6.0-1 https://github.com/LedgerHQ/nanos-secure-sdk.git $BOLOS_ENV/nanos-secure-sdk
 # RUN sudo git clone https://github.com/ledgerhq/blue-secure-sdk $BOLOS_ENV/blue-secure-sdk
 RUN sudo apt-get update && sudo apt-get install -y python3-pip
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,19 +14,19 @@ RUN dpkg --add-architecture i386
 RUN apt-get update && \
     apt-get -y install libudev-dev libusb-1.0-0-dev && \
     apt-get -y install libc6:i386 libncurses5:i386 libstdc++6:i386 libc6-dev-i386 -y > /dev/null && \
-    apt-get -y install binutils-arm-none-eabi
+    apt-get -y install binutils-arm-none-eabi  zlib1g zlib1g-dev
 
 # ARM compilers
 ADD install_compiler.sh /tmp/install_compiler.sh
 RUN /tmp/install_compiler.sh
 
 # Python
-RUN apt-get update && apt-get -y install python3 python3-pip
-RUN pip3 install -U setuptools ledgerblue pillow
+RUN apt-get update && apt-get -y install python3 python3-dev python3-pip libjpeg-dev libffi-dev libssl-dev  cython libhidapi-dev
+RUN pip3 install -U setuptools pillow ledgerblue
 
 # ENV
 RUN echo "export BOLOS_SDK=/opt/bolos/nanos-secure-sdk" >> /home/test/.bashrc
-RUN ln -s /usr/bin/python3 /usr/bin/python
+#RUN ln -s /usr/bin/python3 /usr/bin/python
 
 
 ENV BOLOS_ENV=/opt/bolos

--- a/Dockerfile.nanox
+++ b/Dockerfile.nanox
@@ -25,7 +25,9 @@ RUN /tmp/install_compiler.sh
 
 # Python
 RUN apt-get update && apt-get -y install python3 python3-pip
-RUN pip3 install -U setuptools ledgerblue pillow
+RUN apt-get -y install libjpeg-dev libffi-dev libssl-dev  cython libhidapi-dev  zlib1g zlib1g-dev
+RUN pip3 install -U setuptools pillow
+RUN pip3 install  ledgerblue
 
 # ENV
 # RUN echo "export BOLOS_SDK=/opt/bolos/nanos-secure-sdk" >> /home/test/.bashrc
@@ -39,7 +41,7 @@ ENV BOLOS_ENV=/opt/bolos
 ENV BOLOS_SDK=$BOLOS_ENV/sdk-nanox-1.2.4-1.5
 
 # RUN sudo git clone https://github.com/LedgerHQ/nanos-secure-sdk.git $BOLOS_ENV/nanos-secure-sdk
-RUN sudo git clone https://github.com/LedgerHQ/nanox-secure-sdk $BOLOS_ENV/sdk-nanox-1.2.4-1.5
+RUN sudo git clone -b 1.2.4-5.1 https://github.com/LedgerHQ/nanox-secure-sdk $BOLOS_ENV/sdk-nanox-1.2.4-1.5
 
 # COPY sdk-nanox-1.2.4-1.5/ /opt/bolos/sdk-nanox-1.2.4-1.5/
 # RUN sudo apt-get update && sudo apt-get install -y python3-pip

--- a/src/getTxnSig.c
+++ b/src/getTxnSig.c
@@ -33,17 +33,9 @@ SOFTWARE.
 static signTxnContext_t *ctx = &global.signTxnContext;
 
 static void assign_shard_string() {
-    uint8_t shardStr[5];
-    int shardStrlen;
-
-    strncpy((char*)&ctx->shardStr[0], "from:", 5);
-    memset(shardStr, 0, sizeof(shardStr));
-    shardStrlen = bin2dec(shardStr, ctx->txContent.fromShard);
-    strncpy((char*)&ctx->shardStr[5], shardStr, shardStrlen);
-    strncpy((char*)&ctx->shardStr[5 + shardStrlen], " to:", 4);
-    memset(shardStr, 0, sizeof(shardStr));
-    bin2dec(shardStr, ctx->txContent.toShard);
-    strncpy((char*)&ctx->shardStr[9 + shardStrlen], shardStr, sizeof(shardStr));
+    snprintf(ctx->shardStr,64, "from:%d to:%d", 
+                        ctx->txContent.fromShard, 
+                        ctx->txContent.toShard);
 }
 
 #if defined(HAVE_UX_FLOW)

--- a/src/rlp.c
+++ b/src/rlp.c
@@ -222,7 +222,7 @@ static void processValue(txContext_t *context, txInt256_t *value) {
 }
 
 
-static void processShard(txContext_t *context, uint8_t *shard) {
+static void processShard(txContext_t *context, uint32_t *shard) {
     if (context->currentFieldPos < context->currentFieldLength) {
         uint32_t copySize =
                 (context->commandLength <
@@ -235,12 +235,13 @@ static void processShard(txContext_t *context, uint8_t *shard) {
 
         //adjust from big endian to little endian
         uint32_t shardId = 0;
-        uint8_t *shardIdArray = (uint8_t *) &context->content->fromShard;
-        for(uint32_t i = 0 ; i < context->currentFieldLength;  i++ ) {
+        uint8_t *shardIdArray = (uint8_t *) shard;
+        for(uint32_t i = 0 ; i < copySize;  i++ ) {
             shardId <<= 8;
             shardId |= shardIdArray[i];
         }
-        context->content->fromShard = shardId;
+
+        *shard = shardId;
     }
     if (context->currentFieldPos == context->currentFieldLength) {
         context->txCurrentField++;
@@ -393,10 +394,10 @@ int processTx(txContext_t *context) {
                 processGas(context, &context->content->startgas);
                 break;
             case TX_RLP_FROMSHARD:
-                processShard(context, (uint8_t *)&context->content->fromShard);
+                processShard(context, &context->content->fromShard);
                 break;
             case TX_RLP_TOSHARD:
-                processShard(context, (uint8_t *)&context->content->toShard);
+                processShard(context, &context->content->toShard);
                 break;
             case TX_RLP_TO:
                 processAddress(context, context->content->destination);

--- a/src/ui.h
+++ b/src/ui.h
@@ -93,7 +93,7 @@ typedef struct {
     uint8_t amountStr[78];
     uint32_t amountLength;
     uint8_t partialAmountStr[13];
-    uint8_t shardStr[13];
+    uint8_t shardStr[64];
     uint8_t hash[32];
     uint8_t fullStr[128]; // variable length
     uint8_t typeStr[40]; // variable-length


### PR DESCRIPTION
by default nanos-secure-sdk dependency was pulled from master branch which has 2.0.+ code. so downgrading to 1.6 branch.