### PR TITLE
Review fixes (untested)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,52 @@
+name: CI
+
+on:
+  # Triggers the workflow on push or pull request events but only for the master branch
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    container:
+      image: ghcr.io/ledgerhq/ledger-app-builder/ledger-app-builder:latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build app
+        run: |
+          make clean
+          make DEBUG=1
+
+      - name: Upload app binary
+        uses: actions/upload-artifact@v2
+        with:
+          name: app-debug
+          path: bin
+
+  scan-build:
+    name: Clang Static Analyzer
+    runs-on: ubuntu-latest
+
+    container:
+      image: ghcr.io/ledgerhq/ledger-app-builder/ledger-app-builder:latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build with Clang Static Analyzer
+        run: |
+          make clean
+          scan-build --use-cc=clang -analyze-headers -enable-checker security -enable-checker unix -enable-checker valist -o scan-build --status-bugs make default
+      - uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: scan-build
+          path: scan-build

--- a/src/getPublicKey.c
+++ b/src/getPublicKey.c
@@ -147,7 +147,7 @@ static unsigned int ui_getPublicKey_compare_button(unsigned int button_mask, uns
 		if (ctx->displayIndex > 0) {
 			ctx->displayIndex--;
 		}
-		os_memmove(ctx->partialStr, ctx->fullStr+ctx->displayIndex, 12);
+		memmove(ctx->partialStr, ctx->fullStr+ctx->displayIndex, 12);
 		UX_REDISPLAY();
 		break;
 
@@ -156,7 +156,7 @@ static unsigned int ui_getPublicKey_compare_button(unsigned int button_mask, uns
 		if (ctx->displayIndex < MAX_ONE_ADDRESS - 12) {
 			ctx->displayIndex++;
 		}
-		os_memmove(ctx->partialStr, ctx->fullStr+ctx->displayIndex, 12);
+		memmove(ctx->partialStr, ctx->fullStr+ctx->displayIndex, 12);
 		UX_REDISPLAY();
 		break;
 
@@ -189,11 +189,11 @@ static unsigned int ui_getPublicKey_approve_button(unsigned int button_mask, uns
         getPublicKey();
 
 		// Prepare the comparison screen, filling in the header and body text.
-		os_memmove(ctx->typeStr, "Compare:", 9);
-		os_memmove(ctx->fullStr, G_io_apdu_buffer, MAX_ONE_ADDRESS);
+		memmove(ctx->typeStr, "Compare:", 9);
+		memmove(ctx->fullStr, G_io_apdu_buffer, MAX_ONE_ADDRESS);
 		ctx->fullStr[MAX_ONE_ADDRESS] = '\0';
 
-		os_memmove(ctx->partialStr, ctx->fullStr, 12);
+		memmove(ctx->partialStr, ctx->fullStr, 12);
 		ctx->partialStr[12] = '\0';
 		ctx->displayIndex = 0;
 
@@ -211,17 +211,17 @@ static unsigned int ui_getPublicKey_approve_button(unsigned int button_mask, uns
 #define P2_SILENT_MODE     0x01
 
 void handleGetPublicKey(uint8_t p1, uint8_t p2, uint8_t *dataBuffer, uint16_t dataLength, volatile unsigned int *flags, volatile unsigned int *tx) {
-    os_memset(ctx, 0, sizeof(getPublicKeyContext_t));
+    memset(ctx, 0, sizeof(getPublicKeyContext_t));
 
     if (p2 == P2_DISPLAY_ADDRESS) {
 #if defined(HAVE_UX_FLOW)
         int16_t tx = getOneAddress();
-        os_memmove(ctx->fullStr, G_io_apdu_buffer, tx);
+        memmove(ctx->fullStr, G_io_apdu_buffer, tx);
         ctx->fullStr[tx] = '\0';
         ux_flow_init(0, ux_display_public_flow, NULL);
 #else
         // Prepare the approval screen, filling in the header and body text.
-        os_memmove(ctx->typeStr, "Display Address?", 17);
+        memmove(ctx->typeStr, "Display Address?", 17);
         UX_DISPLAY(ui_getPublicKey_approve, NULL);
 #endif
     }

--- a/src/getTxnSig.c
+++ b/src/getTxnSig.c
@@ -155,7 +155,7 @@ static unsigned int ui_tx_approve_button(unsigned int button_mask, unsigned int 
             cx_keccak_init(&sha3, 256);
             cx_hash((cx_hash_t *)&sha3, CX_LAST, ctx->buf, ctx->length, ctx->hash, 32);
             //debug the hash
-            //os_memmove(G_io_apdu_buffer, ctx->hash, 32);
+            //memmove(G_io_apdu_buffer, ctx->hash, 32);
             //io_exchange_with_code(SW_OK, 32);
             deriveAndSign(G_io_apdu_buffer, ctx->hash);
             io_exchange_with_code(SW_OK, SIGNATURE_LEN);
@@ -227,10 +227,10 @@ static unsigned int ui_amount_compare_large_button(unsigned int button_mask, uns
                 ctx->displayIndex--;
             }
             if (ctx->amountLength > 12) {
-                os_memmove(ctx->partialAmountStr, ctx->amountStr + ctx->displayIndex, 12);
+                memmove(ctx->partialAmountStr, ctx->amountStr + ctx->displayIndex, 12);
             }
             else {
-                os_memmove(ctx->partialAmountStr, ctx->amountStr + ctx->displayIndex, ctx->amountLength);
+                memmove(ctx->partialAmountStr, ctx->amountStr + ctx->displayIndex, ctx->amountLength);
             }
             // Re-render the screen.
             UX_REDISPLAY();
@@ -242,10 +242,10 @@ static unsigned int ui_amount_compare_large_button(unsigned int button_mask, uns
                 ctx->displayIndex++;
             }
             if (ctx->amountLength > 12) {
-                os_memmove(ctx->partialAmountStr, ctx->amountStr + ctx->displayIndex, 12);
+                memmove(ctx->partialAmountStr, ctx->amountStr + ctx->displayIndex, 12);
             }
             else {
-                os_memmove(ctx->partialAmountStr, ctx->amountStr + ctx->displayIndex, ctx->amountLength);
+                memmove(ctx->partialAmountStr, ctx->amountStr + ctx->displayIndex, ctx->amountLength);
             }
             UX_REDISPLAY();
             break;
@@ -319,7 +319,7 @@ static unsigned int ui_address_compare_button(unsigned int button_mask, unsigned
                 ctx->displayIndex--;
             }
 
-            os_memmove(ctx->partialAddrStr, ctx->toAddr+ctx->displayIndex, 12);
+            memmove(ctx->partialAddrStr, ctx->toAddr+ctx->displayIndex, 12);
             // Re-render the screen.
             UX_REDISPLAY();
             break;
@@ -329,25 +329,25 @@ static unsigned int ui_address_compare_button(unsigned int button_mask, unsigned
             if (ctx->displayIndex < sizeof(ctx->toAddr)-12) {
                 ctx->displayIndex++;
             }
-            os_memmove(ctx->partialAddrStr, ctx->toAddr+ctx->displayIndex, 12);
+            memmove(ctx->partialAddrStr, ctx->toAddr+ctx->displayIndex, 12);
             UX_REDISPLAY();
             break;
 
         case BUTTON_EVT_RELEASED | BUTTON_LEFT | BUTTON_RIGHT: // PROCEED
-            os_memset(numberBuf, 0, 32);
-            os_memcpy(&numberBuf[32- ctx->txContent.value.length], ctx->txContent.value.value, ctx->txContent.value.length);
+            memset(numberBuf, 0, 32);
+            memcpy(&numberBuf[32- ctx->txContent.value.length], ctx->txContent.value.value, ctx->txContent.value.length);
             if ( convertU256ToString(numberBuf, (char *)ctx->amountStr, 78,  &ctx->amountLength) == false) {
                 THROW(EXCEPTION_OVERFLOW);
                 return 0;
             }
             ctx->displayIndex = 0;
             if (ctx->amountLength > 12) {
-                os_memmove(ctx->partialAmountStr, ctx->amountStr, 12);
+                memmove(ctx->partialAmountStr, ctx->amountStr, 12);
                 ctx->partialAmountStr[12] = 0;
                 UX_DISPLAY(ui_amount_compare_large, ui_prepro_amount_compare);
             }
             else {
-                os_memmove(ctx->partialAmountStr, ctx->amountStr, ctx->amountLength);
+                memmove(ctx->partialAmountStr, ctx->amountStr, ctx->amountLength);
                 ctx->partialAmountStr[ctx->amountLength] = 0;
                 UX_DISPLAY(ui_amount_compare, NULL);
             }
@@ -377,7 +377,7 @@ static unsigned int ui_signTx_approve_button(unsigned int button_mask, unsigned 
         case BUTTON_EVT_RELEASED | BUTTON_RIGHT: // APPROVE
             processTx(& ctx->txContext);
             bech32_get_address((char *)ctx->toAddr, ctx->txContent.destination, 20);
-            os_memmove(ctx->partialAddrStr, ctx->toAddr, 12);
+            memmove(ctx->partialAddrStr, ctx->toAddr, 12);
             ctx->partialAddrStr[12] = '\0';
             ctx->displayIndex = 0;
             UX_DISPLAY(ui_address_compare, ui_prepro_address_compare);
@@ -390,8 +390,8 @@ static unsigned int ui_signTx_approve_button(unsigned int button_mask, unsigned 
 
 void handleSignTx(uint8_t p1, uint8_t p2, uint8_t *dataBuffer, uint16_t dataLength, volatile unsigned int *flags, volatile unsigned int *tx) {
     if (p1 == P1_FIRST) {
-        os_memset(ctx, 0, sizeof(signTxnContext_t));
-        os_memset(& ctx->txContext, 0, sizeof(ctx->txContext));
+        memset(ctx, 0, sizeof(signTxnContext_t));
+        memset(& ctx->txContext, 0, sizeof(ctx->txContext));
         ctx->length = 0;
 
         ctx->txContext.workBuffer = ctx->buf;
@@ -405,7 +405,7 @@ void handleSignTx(uint8_t p1, uint8_t p2, uint8_t *dataBuffer, uint16_t dataLeng
     }
 
     // Add the new data to transaction decoder.
-    os_memmove(ctx->buf + ctx->length, dataBuffer, dataLength);
+    memmove(ctx->buf + ctx->length, dataBuffer, dataLength);
     ctx->length += dataLength;
 
     // Get more packets
@@ -424,8 +424,8 @@ void handleSignTx(uint8_t p1, uint8_t p2, uint8_t *dataBuffer, uint16_t dataLeng
     processTx(& ctx->txContext);
     bech32_get_address((char *)ctx->toAddr, ctx->txContent.destination, 20);
 
-    os_memset(numberBuf, 0, 32);
-    os_memcpy(&numberBuf[32- ctx->txContent.value.length], ctx->txContent.value.value, ctx->txContent.value.length);
+    memset(numberBuf, 0, 32);
+    memcpy(&numberBuf[32- ctx->txContent.value.length], ctx->txContent.value.value, ctx->txContent.value.length);
     if ( convertU256ToString(numberBuf, (char *)ctx->amountStr, 78,  &ctx->amountLength) == false) {
     	THROW(EXCEPTION_OVERFLOW);
     }
@@ -433,7 +433,7 @@ void handleSignTx(uint8_t p1, uint8_t p2, uint8_t *dataBuffer, uint16_t dataLeng
     assign_shard_string();
     ux_flow_init(0, ux_approval_tx_flow, NULL);
 #else
-    os_memmove(ctx->typeStr, "Review Transaction?", 19);
+    memmove(ctx->typeStr, "Review Transaction?", 19);
     UX_DISPLAY(ui_signTx_approve, NULL);
 #endif
 

--- a/src/harmony.c
+++ b/src/harmony.c
@@ -53,7 +53,7 @@ void deriveOneKeypair(cx_ecfp_private_key_t *privateKey, cx_ecfp_public_key_t *p
 }
 
 void extractPubkeyBytes(unsigned char *dst, cx_ecfp_public_key_t *publicKey) {
-    os_memmove(dst, publicKey->W, SIGNATURE_LEN);
+    memmove(dst, publicKey->W, SIGNATURE_LEN);
 }
 
 
@@ -67,8 +67,8 @@ void convert_signature_to_RSV(const unsigned char *tlv_signature, unsigned char 
     const int offset_before_R = 4;
     const int offset_before_S = 2;
 
-    os_memmove(dst, tlv_signature + offset_before_R + r_offset, 32); // skip first bytes and store the `R` part
-    os_memmove(dst + 32, tlv_signature + offset_before_R + 32 + offset_before_S + r_offset + s_offset,
+    memmove(dst, tlv_signature + offset_before_R + r_offset, 32); // skip first bytes and store the `R` part
+    memmove(dst + 32, tlv_signature + offset_before_R + 32 + offset_before_S + r_offset + s_offset,
                32); // skip unused bytes and store the `S` part
 }
 
@@ -114,7 +114,7 @@ void getEthAddressFromKey(cx_ecfp_public_key_t *publicKey, uint8_t *out) {
     uint8_t hashAddress[32];
     cx_keccak_init(&sha3Context, 256);
     cx_hash((cx_hash_t*)&sha3Context, CX_LAST, publicKey->W + 1, 64, hashAddress, 32);
-    os_memmove(out, hashAddress + 12, 20);
+    memmove(out, hashAddress + 12, 20);
 }
 
 void pubkeyToOneAddress(uint8_t *dst, cx_ecfp_public_key_t *publicKey) {

--- a/src/rlp.c
+++ b/src/rlp.c
@@ -580,8 +580,8 @@ int processStaking(struct txContext_t *context) {
                 break;
             case STAKE_RLP_BLSPUBKEY:
                 processBlsData(context,  (uint8_t *)context->content->blsPubKey);
-                if (context->currentBlsKeyIndex * 13 < BLS_KEY_STR_LEN) {
-                    char *blsPtr = (char *)context->content->blsKeyStr + context->currentBlsKeyIndex * 13;
+                if (context->currentBlsKeyIndex * 13 + 13 < BLS_KEY_STR_LEN) {
+                    char *blsPtr = (char *)&context->content->blsKeyStr[context->currentBlsKeyIndex * 13];
                     to_hex(blsPtr, (unsigned char *)context->content->blsPubKey, 10);
                     blsPtr[10] = '.';
                     blsPtr[11] = '.';

--- a/src/rlp.c
+++ b/src/rlp.c
@@ -57,7 +57,7 @@ static void processContent(txContext_t *context) {
 
 void copyTxData(txContext_t *context, uint8_t *out, uint32_t length) {
     if (out != NULL) {
-        os_memmove(out, context->workBuffer, length);
+        memmove(out, context->workBuffer, length);
     }
     context->workBuffer += length;
     context->commandLength -= length;
@@ -512,7 +512,7 @@ int processStaking(struct txContext_t *context) {
                 context->processingField = false;
                 break;
             case STAKE_RLP_NAME:
-                os_memset(context->content->name, 0, MAX_NAME_LEN);
+                memset(context->content->name, 0, MAX_NAME_LEN);
                 processString(context, (uint8_t *)context->content->name, MAX_NAME_LEN);
                 break;
             case STAKE_RLP_IDENTITY:
@@ -610,7 +610,7 @@ int processStaking(struct txContext_t *context) {
                 }
                 break;
             case STAKE_RLP_SLOTKEYTOREMOVE:
-                os_memmove(context->content->blsKeyStr, "remove:", 7);
+                memmove(context->content->blsKeyStr, "remove:", 7);
                 processBlsData(context,  (uint8_t *)context->content->blsPubKey);
                 to_hex((char *)context->content->blsKeyStr + 7, (unsigned char *)context->content->blsPubKey, 10);
                 context->content->blsKeyStr[17] = '.';
@@ -618,7 +618,7 @@ int processStaking(struct txContext_t *context) {
                 context->content->blsKeyStr[19] = '.';
                 break;
             case STAKE_RLP_SLOTKEYTOADD:
-                os_memmove(context->content->blsKeyStr + 20, ",add:", 5);
+                memmove(context->content->blsKeyStr + 20, ",add:", 5);
                 processBlsData(context,  (uint8_t *)context->content->blsPubKey);
                 to_hex((char *)context->content->blsKeyStr + 25, (unsigned char *)context->content->blsPubKey, 10);
                 context->content->blsKeyStr[35] = '.';
@@ -637,11 +637,11 @@ int processStaking(struct txContext_t *context) {
 	    case STAKE_RLP_EDITACTIVE:
                 processShard(context, &context->content->fromShard);
 		if (context->content->fromShard == 0) {
-                    os_memmove(context->content->destination, "Status:Same", 11);
+                    memmove(context->content->destination, "Status:Same", 11);
                 } else if (context->content->fromShard == 1) {
-                    os_memmove(context->content->destination, "Status:Active", 13);
+                    memmove(context->content->destination, "Status:Active", 13);
                 } else {
-                    os_memmove(context->content->destination, "Status:Inactive", 15);
+                    memmove(context->content->destination, "Status:Inactive", 15);
                 }
                 context->stakeCurrentField = STAKE_RLP_DONE;
                 break;

--- a/src/staking.c
+++ b/src/staking.c
@@ -240,7 +240,7 @@ static unsigned int ui_bls_keys_button(unsigned int button_mask, unsigned int bu
             if (ctx->displayIndex > 0) {
                 ctx->displayIndex--;
             }
-            os_memmove(ctx->partialStr, ctx->fullStr+ctx->displayIndex, 12);
+            memmove(ctx->partialStr, ctx->fullStr+ctx->displayIndex, 12);
             // Re-render the screen.
             UX_REDISPLAY();
             break;
@@ -250,7 +250,7 @@ static unsigned int ui_bls_keys_button(unsigned int button_mask, unsigned int bu
             if (ctx->displayIndex < ctx->fullStrLength - 12) {
                 ctx->displayIndex++;
             }
-            os_memmove(ctx->partialStr, ctx->fullStr+ctx->displayIndex, 12);
+            memmove(ctx->partialStr, ctx->fullStr+ctx->displayIndex, 12);
             UX_REDISPLAY();
             break;
 
@@ -282,7 +282,7 @@ static unsigned int ui_delegation_rate_button(unsigned int button_mask, unsigned
             if (ctx->displayIndex > 0) {
                 ctx->displayIndex--;
             }
-            os_memmove(ctx->partialStr, ctx->fullStr + ctx->displayIndex, 12);
+            memmove(ctx->partialStr, ctx->fullStr + ctx->displayIndex, 12);
             // Re-render the screen.
             UX_REDISPLAY();
             break;
@@ -292,28 +292,28 @@ static unsigned int ui_delegation_rate_button(unsigned int button_mask, unsigned
             if (ctx->displayIndex < ctx->fullStrLength - 12) {
                 ctx->displayIndex++;
             }
-            os_memmove(ctx->partialStr, ctx->fullStr + ctx->displayIndex, 12);
+            memmove(ctx->partialStr, ctx->fullStr + ctx->displayIndex, 12);
             UX_REDISPLAY();
             break;
 
         case BUTTON_EVT_RELEASED | BUTTON_LEFT | BUTTON_RIGHT: // PROCEED
-            os_memset(ctx->fullStr, 0, sizeof(ctx->fullStr));
+            memset(ctx->fullStr, 0, sizeof(ctx->fullStr));
             if ( ctx->txContent.directive == DirectiveCreateValidator)  {
                 int totalNumOfKeysToDisplay = ctx->txContent.blsPubKeySize;
                 //cap at 10 BLS keys, each key takes 13 bytes
                 if (totalNumOfKeysToDisplay > 10) {
                     totalNumOfKeysToDisplay = 10;
                 }
-                os_memmove(ctx->fullStr, ctx->txContent.blsKeyStr, 13 * totalNumOfKeysToDisplay);
+                memmove(ctx->fullStr, ctx->txContent.blsKeyStr, 13 * totalNumOfKeysToDisplay);
                 offset += 13 * totalNumOfKeysToDisplay;
             } else {
                 //7 + 13 + 5 + 13 = 38 bytes
-                os_memmove(ctx->fullStr, ctx->txContent.blsKeyStr, 38);
+                memmove(ctx->fullStr, ctx->txContent.blsKeyStr, 38);
                 offset += 38;
             }
 
             ctx->fullStrLength = offset;
-            os_memmove(ctx->partialStr, ctx->fullStr, 12);
+            memmove(ctx->partialStr, ctx->fullStr, 12);
             UX_DISPLAY(ui_bls_keys, NULL);
             break;
     }
@@ -340,7 +340,7 @@ static unsigned int ui_commission_rate_button(unsigned int button_mask, unsigned
             if (ctx->displayIndex > 0) {
                 ctx->displayIndex--;
             }
-            os_memmove(ctx->partialStr, ctx->fullStr + ctx->displayIndex, 12);
+            memmove(ctx->partialStr, ctx->fullStr + ctx->displayIndex, 12);
             // Re-render the screen.
             UX_REDISPLAY();
             break;
@@ -350,7 +350,7 @@ static unsigned int ui_commission_rate_button(unsigned int button_mask, unsigned
             if (ctx->displayIndex < ctx->fullStrLength - 12) {
                 ctx->displayIndex++;
             }
-            os_memmove(ctx->partialStr, ctx->fullStr + ctx->displayIndex, 12);
+            memmove(ctx->partialStr, ctx->fullStr + ctx->displayIndex, 12);
             UX_REDISPLAY();
             break;
 
@@ -361,13 +361,13 @@ static unsigned int ui_commission_rate_button(unsigned int button_mask, unsigned
                 //re-use hash buf to save stack space
                 uint8_t *numberBuf = &ctx->hash[0];
 
-                os_memset(ctx->fullStr, 0, sizeof(ctx->fullStr));
+                memset(ctx->fullStr, 0, sizeof(ctx->fullStr));
 
                 if (ctx->txContent.directive == DirectiveCreateValidator) {
-                    os_memmove(ctx->fullStr + offset, "amount:", 7);
+                    memmove(ctx->fullStr + offset, "amount:", 7);
                     offset += 7;
-                    os_memset(numberBuf, 0, 32);
-                    os_memmove(&numberBuf[32 - ctx->txContent.value.length], ctx->txContent.value.value,
+                    memset(numberBuf, 0, 32);
+                    memmove(&numberBuf[32 - ctx->txContent.value.length], ctx->txContent.value.value,
                                ctx->txContent.value.length);
                     if (convertU256ToString(numberBuf, (char *)ctx->fullStr + offset, 78, &outLen) == false) {
                         THROW(EXCEPTION_OVERFLOW);
@@ -376,15 +376,15 @@ static unsigned int ui_commission_rate_button(unsigned int button_mask, unsigned
 
                     offset += outLen;
 
-                    os_memmove(ctx->fullStr + offset, ",min:", 5);
+                    memmove(ctx->fullStr + offset, ",min:", 5);
                     offset += 5;
                 } else {
-                    os_memmove(ctx->fullStr + offset, "min:", 4);
+                    memmove(ctx->fullStr + offset, "min:", 4);
                     offset += 4;
                 }
 
-                os_memset(numberBuf, 0, 32);
-                os_memmove(&numberBuf[32 - ctx->txContent.minSelfDelegation.length],
+                memset(numberBuf, 0, 32);
+                memmove(&numberBuf[32 - ctx->txContent.minSelfDelegation.length],
                            ctx->txContent.minSelfDelegation.value, ctx->txContent.minSelfDelegation.length);
                 if (convertU256ToString(numberBuf, (char *)ctx->fullStr + offset, 78, &outLen) == false) {
                     THROW(EXCEPTION_OVERFLOW);
@@ -392,10 +392,10 @@ static unsigned int ui_commission_rate_button(unsigned int button_mask, unsigned
                 }
                 offset += outLen;
 
-                os_memmove(ctx->fullStr + offset, ",max:", 5);
+                memmove(ctx->fullStr + offset, ",max:", 5);
                 offset += 5;
-                os_memset(numberBuf, 0, 32);
-                os_memmove(&numberBuf[32 - ctx->txContent.maxTotalDelegation.length],
+                memset(numberBuf, 0, 32);
+                memmove(&numberBuf[32 - ctx->txContent.maxTotalDelegation.length],
                            ctx->txContent.maxTotalDelegation.value, ctx->txContent.maxTotalDelegation.length);
                 if (convertU256ToString(numberBuf, (char *)ctx->fullStr + offset, 78, &outLen) == false) {
                     THROW(EXCEPTION_OVERFLOW);
@@ -404,7 +404,7 @@ static unsigned int ui_commission_rate_button(unsigned int button_mask, unsigned
                 offset += outLen;
 
                 ctx->fullStrLength = offset;
-                os_memmove(ctx->partialStr, ctx->fullStr, 12);
+                memmove(ctx->partialStr, ctx->fullStr, 12);
                 UX_DISPLAY(ui_delegation_rate, NULL);
             }
             break;
@@ -432,7 +432,7 @@ static unsigned int ui_description_compare_button(unsigned int button_mask, unsi
             if (ctx->displayIndex > 0) {
                 ctx->displayIndex--;
             }
-            os_memmove(ctx->partialStr, ctx->fullStr+ctx->displayIndex, 12);
+            memmove(ctx->partialStr, ctx->fullStr+ctx->displayIndex, 12);
             // Re-render the screen.
             UX_REDISPLAY();
             break;
@@ -442,7 +442,7 @@ static unsigned int ui_description_compare_button(unsigned int button_mask, unsi
             if (ctx->displayIndex < ctx->fullStrLength-12) {
                 ctx->displayIndex++;
             }
-            os_memmove(ctx->partialStr, ctx->fullStr+ctx->displayIndex, 12);
+            memmove(ctx->partialStr, ctx->fullStr+ctx->displayIndex, 12);
             UX_REDISPLAY();
             break;
 
@@ -452,38 +452,38 @@ static unsigned int ui_description_compare_button(unsigned int button_mask, unsi
                 char      output[80];
                 uint32_t  offset = 0;
 
-                os_memset(ctx->fullStr, 0, sizeof(ctx->fullStr));
-                os_memmove(ctx->fullStr + offset, "rate:", 5);
+                memset(ctx->fullStr, 0, sizeof(ctx->fullStr));
+                memmove(ctx->fullStr + offset, "rate:", 5);
                 offset += 5;
                 if (convertNumericDecimalToString(ctx->txContent.rate.value, ctx->txContent.rate.length, output) == false) {
                     THROW(EXCEPTION_OVERFLOW);
                     return 0;
                 }
-                os_memmove(ctx->fullStr + offset , output, strlen(output));
+                memmove(ctx->fullStr + offset , output, strlen(output));
                 offset += strlen(output);
 
                 if (ctx->txContent.directive == DirectiveCreateValidator) {
-                    os_memmove(ctx->fullStr + offset, ",max:", 5);
+                    memmove(ctx->fullStr + offset, ",max:", 5);
                     offset += 5;
                     if (convertNumericDecimalToString(ctx->txContent.maxRate.value, ctx->txContent.maxRate.length, output) == false) {
                         THROW(EXCEPTION_OVERFLOW);
                         return 0;
                     }
-                    os_memmove(ctx->fullStr + offset , output, strlen(output));
+                    memmove(ctx->fullStr + offset , output, strlen(output));
                     offset += strlen(output);
 
-                    os_memmove(ctx->fullStr + offset, ",change:", 8);
+                    memmove(ctx->fullStr + offset, ",change:", 8);
                     offset += 8;
                     if (convertNumericDecimalToString(ctx->txContent.maxChangeRate.value, ctx->txContent.maxChangeRate.length, output) == false) {
                         THROW(EXCEPTION_OVERFLOW);
                         return 0;
                     }
-                    os_memmove(ctx->fullStr + offset , output, strlen(output));
+                    memmove(ctx->fullStr + offset , output, strlen(output));
                     offset += strlen(output);
                 }
 
                 ctx->fullStrLength = offset;
-                os_memmove(ctx->partialStr, ctx->fullStr, 12);
+                memmove(ctx->partialStr, ctx->fullStr, 12);
                 UX_DISPLAY(ui_commission_rate, NULL);
             }
             break;
@@ -515,10 +515,10 @@ static unsigned int ui_amount_compare_large_button(unsigned int button_mask, uns
                 ctx->displayIndex--;
             }
             if (ctx->fullStrLength > 12) {
-                os_memmove(ctx->partialStr, ctx->fullStr + ctx->displayIndex, 12);
+                memmove(ctx->partialStr, ctx->fullStr + ctx->displayIndex, 12);
             }
             else {
-                os_memmove(ctx->partialStr, ctx->fullStr + ctx->displayIndex, ctx->fullStrLength);
+                memmove(ctx->partialStr, ctx->fullStr + ctx->displayIndex, ctx->fullStrLength);
             }
             // Re-render the screen.
             UX_REDISPLAY();
@@ -530,10 +530,10 @@ static unsigned int ui_amount_compare_large_button(unsigned int button_mask, uns
                 ctx->displayIndex++;
             }
             if (ctx->fullStrLength > 12) {
-                os_memmove(ctx->partialStr, ctx->fullStr + ctx->displayIndex, 12);
+                memmove(ctx->partialStr, ctx->fullStr + ctx->displayIndex, 12);
             }
             else {
-                os_memmove(ctx->partialStr, ctx->fullStr + ctx->displayIndex, ctx->fullStrLength);
+                memmove(ctx->partialStr, ctx->fullStr + ctx->displayIndex, ctx->fullStrLength);
             }
             UX_REDISPLAY();
             break;
@@ -591,7 +591,7 @@ static unsigned int ui_validator_address_compare_button(unsigned int button_mask
                 ctx->displayIndex--;
             }
 
-            os_memmove(ctx->partialStr, ctx->fullStr+ctx->displayIndex, 12);
+            memmove(ctx->partialStr, ctx->fullStr+ctx->displayIndex, 12);
             // Re-render the screen.
             UX_REDISPLAY();
             break;
@@ -601,24 +601,24 @@ static unsigned int ui_validator_address_compare_button(unsigned int button_mask
             if (ctx->displayIndex < ctx->fullStrLength-12) {
                 ctx->displayIndex++;
             }
-            os_memmove(ctx->partialStr, ctx->fullStr+ctx->displayIndex, 12);
+            memmove(ctx->partialStr, ctx->fullStr+ctx->displayIndex, 12);
             UX_REDISPLAY();
             break;
 
         case BUTTON_EVT_RELEASED | BUTTON_LEFT | BUTTON_RIGHT: // PROCEED
-            os_memset(ctx->fullStr, 0, sizeof(ctx->fullStr));
+            memset(ctx->fullStr, 0, sizeof(ctx->fullStr));
             if ( (ctx->txContent.directive == DirectiveCreateValidator) ||
                  (ctx->txContent.directive == DirectiveEditValidator) ) {
-                    os_memmove(ctx->fullStr, ctx->txContent.name, strlen(ctx->txContent.name));
+                    memmove(ctx->fullStr, ctx->txContent.name, strlen(ctx->txContent.name));
                     ctx->fullStrLength = strlen(ctx->txContent.name);
-                    os_memmove(ctx->partialStr, ctx->fullStr, 12);
+                    memmove(ctx->partialStr, ctx->fullStr, 12);
                     UX_DISPLAY(ui_description_compare, NULL);
 
             } else {
                 //re-use hash buf to save stack space
                 uint8_t *numberBuf = &ctx->hash[0];
-                os_memset(numberBuf, 0, 32);
-                os_memcpy(&numberBuf[32 - ctx->txContent.value.length], ctx->txContent.value.value,
+                memset(numberBuf, 0, 32);
+                memcpy(&numberBuf[32 - ctx->txContent.value.length], ctx->txContent.value.value,
                           ctx->txContent.value.length);
                 if (convertU256ToString(numberBuf, (char *)ctx->fullStr, 78, &ctx->fullStrLength) == false) {
                     THROW(EXCEPTION_OVERFLOW);
@@ -626,11 +626,11 @@ static unsigned int ui_validator_address_compare_button(unsigned int button_mask
                 }
                 ctx->displayIndex = 0;
                 if (ctx->fullStrLength > 12) {
-                    os_memmove(ctx->partialStr, ctx->fullStr, 12);
+                    memmove(ctx->partialStr, ctx->fullStr, 12);
                     ctx->partialStr[12] = 0;
                     UX_DISPLAY(ui_amount_compare_large, NULL);
                 } else {
-                    os_memmove(ctx->partialStr, ctx->fullStr, ctx->fullStrLength);
+                    memmove(ctx->partialStr, ctx->fullStr, ctx->fullStrLength);
                     ctx->partialStr[ctx->fullStrLength] = 0;
                     UX_DISPLAY(ui_amount_compare, NULL);
                 }
@@ -662,7 +662,7 @@ static unsigned int ui_delegator_address_compare_button(unsigned int button_mask
                 ctx->displayIndex--;
             }
 
-            os_memmove(ctx->partialStr, ctx->fullStr+ctx->displayIndex, 12);
+            memmove(ctx->partialStr, ctx->fullStr+ctx->displayIndex, 12);
             // Re-render the screen.
             UX_REDISPLAY();
             break;
@@ -672,17 +672,17 @@ static unsigned int ui_delegator_address_compare_button(unsigned int button_mask
             if (ctx->displayIndex < ctx->fullStrLength-12) {
                 ctx->displayIndex++;
             }
-            os_memmove(ctx->partialStr, ctx->fullStr+ctx->displayIndex, 12);
+            memmove(ctx->partialStr, ctx->fullStr+ctx->displayIndex, 12);
             UX_REDISPLAY();
             break;
 
         case BUTTON_EVT_RELEASED | BUTTON_LEFT | BUTTON_RIGHT: // PROCEED
-            os_memset(ctx->fullStr, 0, sizeof(ctx->fullStr));
+            memset(ctx->fullStr, 0, sizeof(ctx->fullStr));
             if (ctx->txContent.directive == DirectiveCollectRewards) {
                 UX_DISPLAY(ui_confirm_signing, NULL);
             } else {
                 bech32_get_address((char *) ctx->fullStr, ctx->txContent.validatorAddress, 20);
-                os_memmove(ctx->partialStr, ctx->fullStr, 12);
+                memmove(ctx->partialStr, ctx->fullStr, 12);
                 ctx->partialStr[12] = '\0';
                 ctx->displayIndex = 0;
                 UX_DISPLAY(ui_validator_address_compare, NULL);
@@ -711,19 +711,19 @@ static unsigned int ui_signStaking_approve_button(unsigned int button_mask, unsi
             break;
 
         case BUTTON_EVT_RELEASED | BUTTON_RIGHT: // APPROVE
-            os_memset(ctx->fullStr, 0, sizeof(ctx->fullStr));
+            memset(ctx->fullStr, 0, sizeof(ctx->fullStr));
             if ( (ctx->txContent.directive == DirectiveCreateValidator) ||
                  (ctx->txContent.directive == DirectiveEditValidator) ) {
                 bech32_get_address((char *)ctx->fullStr, ctx->txContent.validatorAddress, 20);
                 ctx->fullStrLength = MAX_ONE_ADDRESS;
-                os_memmove(ctx->partialStr, ctx->fullStr, 12);
+                memmove(ctx->partialStr, ctx->fullStr, 12);
                 ctx->partialStr[12] = '\0';
                 ctx->displayIndex = 0;
                 UX_DISPLAY(ui_validator_address_compare, NULL);
             } else {
                 bech32_get_address((char *) ctx->fullStr, ctx->txContent.destination, 20);
                 ctx->fullStrLength = MAX_ONE_ADDRESS;
-                os_memmove(ctx->partialStr, ctx->fullStr, 12);
+                memmove(ctx->partialStr, ctx->fullStr, 12);
                 ctx->partialStr[12] = '\0';
                 ctx->displayIndex = 0;
                 UX_DISPLAY(ui_delegator_address_compare, NULL);
@@ -737,8 +737,8 @@ static unsigned int ui_signStaking_approve_button(unsigned int button_mask, unsi
 
 void handleSignStaking(uint8_t p1, uint8_t p2, uint8_t *dataBuffer, uint16_t dataLength, volatile unsigned int *flags, volatile unsigned int *tx) {
     if (p1 == P1_FIRST) {
-        os_memset(ctx, 0, sizeof(signStakingContext_t));
-        os_memset(& ctx->txContext, 0, sizeof(ctx->txContext));
+        memset(ctx, 0, sizeof(signStakingContext_t));
+        memset(& ctx->txContext, 0, sizeof(ctx->txContext));
         ctx->length = 0;
 
         ctx->txContext.workBuffer = ctx->buf;
@@ -752,7 +752,7 @@ void handleSignStaking(uint8_t p1, uint8_t p2, uint8_t *dataBuffer, uint16_t dat
     }
 
     // Add the new data to transaction decoder.
-    os_memmove(ctx->buf + ctx->length, dataBuffer, dataLength);
+    memmove(ctx->buf + ctx->length, dataBuffer, dataLength);
     ctx->length += dataLength;
 
     // Get more packets
@@ -771,26 +771,26 @@ void handleSignStaking(uint8_t p1, uint8_t p2, uint8_t *dataBuffer, uint16_t dat
     }
 
     if (ctx->txContent.directive == DirectiveCreateValidator) {
-        os_memmove(ctx->partialStr, "Create Validator", 17);
+        memmove(ctx->partialStr, "Create Validator", 17);
     }
     else if (ctx->txContent.directive == DirectiveEditValidator) {
-        os_memmove(ctx->partialStr, "Edit Validator", 15);
+        memmove(ctx->partialStr, "Edit Validator", 15);
     }
     else if (ctx->txContent.directive == DirectiveDelegate) {
-        os_memmove(ctx->partialStr, "Delegate", 9);
+        memmove(ctx->partialStr, "Delegate", 9);
     }
     else if (ctx->txContent.directive == DirectiveUndelegate) {
-        os_memmove(ctx->partialStr, "Undelegate", 11);
+        memmove(ctx->partialStr, "Undelegate", 11);
     }
     else if (ctx->txContent.directive == DirectiveCollectRewards) {
-        os_memmove(ctx->partialStr, "Collect Rewards", 16);
+        memmove(ctx->partialStr, "Collect Rewards", 16);
     }
     else {
         THROW(INVALID_PARAMETER);
     }
 
 #if defined(HAVE_UX_FLOW)
-    os_memset(ctx->fullStr, 0, sizeof(ctx->fullStr));
+    memset(ctx->fullStr, 0, sizeof(ctx->fullStr));
     if ( (ctx->txContent.directive == DirectiveCreateValidator) ||
     	(ctx->txContent.directive == DirectiveEditValidator) ) {
 
@@ -800,38 +800,38 @@ void handleSignStaking(uint8_t p1, uint8_t p2, uint8_t *dataBuffer, uint16_t dat
          uint32_t  outLen,offset = 0;
 	 uint8_t   *numberBuf = &ctx->hash[0];
 
-         os_memset(ctx->commissionRateStr, 0, sizeof(ctx->commissionRateStr));
-         os_memmove(ctx->commissionRateStr + offset, "rate:", 5);
+         memset(ctx->commissionRateStr, 0, sizeof(ctx->commissionRateStr));
+         memmove(ctx->commissionRateStr + offset, "rate:", 5);
                
 	 offset += 5;
          if (convertNumericDecimalToString(ctx->txContent.rate.value, ctx->txContent.rate.length, output) == false) {
          	THROW(EXCEPTION_OVERFLOW);
          }
 
-         os_memmove(ctx->commissionRateStr + offset , output, strlen(output));
+         memmove(ctx->commissionRateStr + offset , output, strlen(output));
          offset += strlen(output);
 
 	 if (ctx->txContent.directive == DirectiveCreateValidator) {
 		// process commission rate
-         	os_memmove(ctx->commissionRateStr + offset, ",max:", 5);
+         	memmove(ctx->commissionRateStr + offset, ",max:", 5);
                 offset += 5;
                 if (convertNumericDecimalToString(ctx->txContent.maxRate.value, ctx->txContent.maxRate.length, output) == false) {
                 	THROW(EXCEPTION_OVERFLOW);
                 }
 
-                os_memmove(ctx->commissionRateStr + offset , output, strlen(output));
+                memmove(ctx->commissionRateStr + offset , output, strlen(output));
                 offset += strlen(output);
 
-                os_memmove(ctx->commissionRateStr + offset, ",change:", 8);
+                memmove(ctx->commissionRateStr + offset, ",change:", 8);
                 offset += 8;
                 if (convertNumericDecimalToString(ctx->txContent.maxChangeRate.value, ctx->txContent.maxChangeRate.length, output) == false) {
                 	THROW(EXCEPTION_OVERFLOW);
                 }
-                os_memmove(ctx->commissionRateStr + offset , output, strlen(output));
+                memmove(ctx->commissionRateStr + offset , output, strlen(output));
 
 		// process amount
-         	os_memset(numberBuf, 0, 32);
-         	os_memcpy(&numberBuf[32 - ctx->txContent.value.length], ctx->txContent.value.value,
+         	memset(numberBuf, 0, 32);
+         	memcpy(&numberBuf[32 - ctx->txContent.value.length], ctx->txContent.value.value,
                           ctx->txContent.value.length);
          	if (convertU256ToString(numberBuf, (char *)ctx->amountStr, 78, &ctx->fullStrLength) == false) {
                	     THROW(EXCEPTION_OVERFLOW);
@@ -839,37 +839,37 @@ void handleSignStaking(uint8_t p1, uint8_t p2, uint8_t *dataBuffer, uint16_t dat
 	 }
 
          offset = 0;
-         os_memmove(ctx->delegationStr + offset, "min:", 4);
+         memmove(ctx->delegationStr + offset, "min:", 4);
          offset += 4;
 
-         os_memset(numberBuf, 0, 32);
-         os_memmove(&numberBuf[32 - ctx->txContent.minSelfDelegation.length],
+         memset(numberBuf, 0, 32);
+         memmove(&numberBuf[32 - ctx->txContent.minSelfDelegation.length],
                    ctx->txContent.minSelfDelegation.value, ctx->txContent.minSelfDelegation.length);
          if (convertU256ToString(numberBuf, (char *)ctx->delegationStr + offset, 78, &outLen) == false) {
          	THROW(EXCEPTION_OVERFLOW);
          }
 
          offset += outLen;
-         os_memmove(ctx->delegationStr + offset, ",max:", 5);
+         memmove(ctx->delegationStr + offset, ",max:", 5);
          offset += 5;
-         os_memset(numberBuf, 0, 32);
-         os_memmove(&numberBuf[32 - ctx->txContent.maxTotalDelegation.length],
+         memset(numberBuf, 0, 32);
+         memmove(&numberBuf[32 - ctx->txContent.maxTotalDelegation.length],
                    ctx->txContent.maxTotalDelegation.value, ctx->txContent.maxTotalDelegation.length);
          if (convertU256ToString(numberBuf, (char *)ctx->delegationStr + offset, 78, &outLen) == false) {
                    THROW(EXCEPTION_OVERFLOW);
          }
 
-	 os_memset(ctx->fullStr, 0, sizeof(ctx->fullStr));
+	 memset(ctx->fullStr, 0, sizeof(ctx->fullStr));
          if ( ctx->txContent.directive == DirectiveCreateValidator)  {
          	int totalNumOfKeysToDisplay = ctx->txContent.blsPubKeySize;
                 //cap at 10 BLS keys, each key takes 13 bytes
                 if (totalNumOfKeysToDisplay > 10) {
                     totalNumOfKeysToDisplay = 10;
                 }
-                os_memmove(ctx->fullStr, ctx->txContent.blsKeyStr, 13 * totalNumOfKeysToDisplay);
+                memmove(ctx->fullStr, ctx->txContent.blsKeyStr, 13 * totalNumOfKeysToDisplay);
           } else {
                 //7 + 13 + 5 + 13 = 38 bytes
-                os_memmove(ctx->fullStr, ctx->txContent.blsKeyStr, 38);
+                memmove(ctx->fullStr, ctx->txContent.blsKeyStr, 38);
           }
     } else {
          bech32_get_address((char *)ctx->delegatorAddr, ctx->txContent.destination, 20);
@@ -878,8 +878,8 @@ void handleSignStaking(uint8_t p1, uint8_t p2, uint8_t *dataBuffer, uint16_t dat
          	bech32_get_address((char *)ctx->validatorAddr, ctx->txContent.validatorAddress, 20);
 
 	 	uint8_t *numberBuf = &ctx->hash[0];
-         	os_memset(numberBuf, 0, 32);
-         	os_memcpy(&numberBuf[32 - ctx->txContent.value.length], ctx->txContent.value.value,
+         	memset(numberBuf, 0, 32);
+         	memcpy(&numberBuf[32 - ctx->txContent.value.length], ctx->txContent.value.value,
                           ctx->txContent.value.length);
          	if (convertU256ToString(numberBuf, (char *)ctx->amountStr, 78, &ctx->fullStrLength) == false) {
                	     THROW(EXCEPTION_OVERFLOW);
@@ -888,20 +888,20 @@ void handleSignStaking(uint8_t p1, uint8_t p2, uint8_t *dataBuffer, uint16_t dat
     }
 
     if (strlen(ctx->txContent.name) == 0) {
-        os_memcpy(ctx->nameStr, "null", 4 );
+        memcpy(ctx->nameStr, "null", 4 );
     } else {
-        os_memcpy(ctx->nameStr, ctx->txContent.name, strlen(ctx->txContent.name));
+        memcpy(ctx->nameStr, ctx->txContent.name, strlen(ctx->txContent.name));
     }
 
     if (ctx->txContent.directive == DirectiveCreateValidator) {
     	ux_flow_init(0, ux_staking_create_valiator_flow, NULL);
     } else if (ctx->txContent.directive == DirectiveEditValidator)  {
         if (ctx->txContent.fromShard == 0) {
-                os_memmove(ctx->statusStr, "Same", 4 );
+                memmove(ctx->statusStr, "Same", 4 );
 	} else if (ctx->txContent.fromShard == 1) {
-                os_memmove(ctx->statusStr, "Active", 6);
+                memmove(ctx->statusStr, "Active", 6);
 	} else {
-                os_memmove(ctx->statusStr, "Inactive", 8);
+                memmove(ctx->statusStr, "Inactive", 8);
         }
     	ux_flow_init(0, ux_staking_edit_validator_flow, NULL);
     } else if (ctx->txContent.directive == DirectiveCollectRewards) {
@@ -913,9 +913,9 @@ void handleSignStaking(uint8_t p1, uint8_t p2, uint8_t *dataBuffer, uint16_t dat
 #else
     if (ctx->txContent.directive == DirectiveEditValidator)  {
 	// 15 is size of string "Status:Inactive" 
-        os_memmove(ctx->fullStr, ctx->txContent.destination, 15);
+        memmove(ctx->fullStr, ctx->txContent.destination, 15);
     } else {
-        os_memset(ctx->fullStr, 0, sizeof(ctx->fullStr));
+        memset(ctx->fullStr, 0, sizeof(ctx->fullStr));
     }
     UX_DISPLAY(ui_signStaking_approve, NULL);
 #endif

--- a/src/uint256.c
+++ b/src/uint256.c
@@ -517,18 +517,18 @@ bool convertU256ToString(uint8_t *buffer, char *output, uint32_t sizeLimit, uint
     divmod256(&nanoAmount, &nano, &amount, &rMod);
 
     //78 is the maximal possible length of a uint256 string
-    os_memset(stringBuf, 0, 78);
+    memset(stringBuf, 0, 78);
     if (tostring256(&amount, 10, stringBuf, 78,  &len) == false) {
         return false;
     }
 
-    os_memset(output, 0, sizeLimit);
-    os_memmove(output, stringBuf, len);
+    memset(output, 0, sizeLimit);
+    memmove(output, stringBuf, len);
     *outLength = len;
 
     //check for non zero decimal part
     if (! zero256(&rMod)) {
-        os_memset(stringBuf, 0, 78);
+        memset(stringBuf, 0, 78);
         if (tostring256(&rMod, 10, stringBuf, 78,  &len2) == false) {
             return false;
         }
@@ -557,11 +557,11 @@ bool convertU256ToString(uint8_t *buffer, char *output, uint32_t sizeLimit, uint
         }
 
         //pad leading zeros
-        os_memset(&output[len + 1], '0', 9 - len2);
+        memset(&output[len + 1], '0', 9 - len2);
         *outLength += 9 - len2;
 
         //copy remaining digits
-        os_memcpy(&output[len + 1 + 9 - len2], stringBuf, strlen(stringBuf));
+        memcpy(&output[len + 1 + 9 - len2], stringBuf, strlen(stringBuf));
         *outLength += strlen(stringBuf);
     }
 
@@ -620,13 +620,13 @@ bool convertNumericDecimalToString(uint8_t *value,  uint8_t length, char *output
         return false;
     }
 
-    os_memset(numberBuf, 0, sizeof(numberBuf));
-    os_memmove(&numberBuf[32 - length], value, length);
+    memset(numberBuf, 0, sizeof(numberBuf));
+    memmove(&numberBuf[32 - length], value, length);
 
     clear256(&target);
     readu256BE(numberBuf, &target);
 
-    os_memset(stringBuf, 0, sizeof(stringBuf));
+    memset(stringBuf, 0, sizeof(stringBuf));
     if (tostring256(&target, 10, stringBuf, 78, &outLen) == false) {
         return false;
     }


### PR DESCRIPTION
This PR removes the use of the deprecated `os_mem*` function as per [developer recommendations](https://developers.ledger.com/docs/nano-app/secure-app/#good-practices-for-transaction-handling) (end of paragraph).
It also adds a scanbuild Github Action, which has found one (false positive) bug that is fixed here.